### PR TITLE
chore: Switch to self-hosted runners

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
       packages: write
@@ -53,7 +53,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validate-single-commit:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Validate Single Commit Policy
     
     steps:
@@ -53,7 +53,7 @@ jobs:
         fi
 
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Build and Test
     
     steps:


### PR DESCRIPTION
This change modifies the GitHub Actions workflows to use self-hosted runners instead of GitHub-hosted runners (`ubuntu-latest`).

The following workflows have been updated:
- .github/workflows/pr-validation.yml
- .github/workflows/docker-build.yml

## Description
Brief description of changes made in this pull request.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or improvement

## Testing
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Manual testing completed
- [ ] Documentation updated to reflect changes

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information that reviewers should know about this pull request. 